### PR TITLE
CI Hardening â€” Scoped Doppler CI Triggers (Ledger Â§19.5.1)

### DIFF
--- a/.github/workflows/doppler-ci.yml
+++ b/.github/workflows/doppler-ci.yml
@@ -3,7 +3,9 @@ name: Doppler CI
 on:
   workflow_dispatch:
   push:
+    branches: [ main ]
   pull_request:
+    branches: [ main ]
 
 jobs:
   doppler:


### PR DESCRIPTION
This PR updates the Doppler CI workflow triggers to comply with Tippy Decision Ledger §19.5.1, which requires scoped push and pull_request triggers.

Changes:
- push triggers now scoped to `main`
- pull_request triggers now scoped to `main`
- workflow_dispatch retained
- No other changes made

This PR performs a minimal governance-aligned hardening of the CI configuration following the merge of PR #37.
