### PR TITLE
Automate secrets rotation and harden token healthcheck

### DIFF
--- a/.github/workflows/secrets-rotation.yml
+++ b/.github/workflows/secrets-rotation.yml
@@ -1,7 +1,6 @@
-# Token Healthcheck: validate tokens without printing secrets. §19.5, §25.x.
-# Schedule: Sunday 07:00 UTC (09:00 Africa/Johannesburg).
-# Uses Doppler config `ci` for CI secrets (see docs/security/secrets-rotation.md). Use config `dev` if `ci` not yet created.
-name: Token Healthcheck
+# Secrets Rotation: rotate provider secrets, write to Doppler, verify. §19.5, §25.x.
+# Schedule: Sunday 07:00 UTC. Requires DOPPLER_TOKEN_CI (and rotator secrets in Doppler ci config).
+name: Secrets Rotation
 
 on:
   workflow_dispatch:
@@ -12,7 +11,7 @@ env:
   ACTIONS_STEP_DEBUG: 'false'
 
 jobs:
-  healthcheck:
+  rotate:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -20,6 +19,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
 
       - name: Install Doppler CLI
         env:
@@ -33,40 +38,27 @@ jobs:
           sudo tar -C /usr/local/bin -xzf "${ARCHIVE}" doppler
           doppler --version
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'npm'
-
       - name: Install dependencies
         env:
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_CI }}
         run: |
           doppler run --project tippy --config ci -- npm ci
 
-      - name: Validate Doppler token
+      - name: Run secrets rotation
+        id: rotate
         env:
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_CI }}
         run: |
-          doppler run --project tippy --config ci -- echo "Doppler OK"
-
-      - name: Run token validation
-        id: validate
-        env:
-          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_CI }}
-          GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          doppler run --project tippy --config ci -- npx tsx scripts/validate_tokens.ts
+          doppler run --project tippy --config ci -- npx tsx scripts/rotate_secrets.ts
         continue-on-error: true
 
-      - name: Create or update Token Healthcheck Failed issue
-        if: steps.validate.outcome == 'failure'
+      - name: Create or update Secrets Rotation Failed issue
+        if: steps.rotate.outcome == 'failure'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          echo "One or more tokens failed validation."
+          echo "Secrets rotation failed. See workflow logs for secret NAMES and error summary (no values)."
 
-      - name: Fail job if validation failed
-        if: steps.validate.outcome == 'failure'
+      - name: Fail job if rotation failed
+        if: steps.rotate.outcome == 'failure'
         run: exit 1

--- a/docs/security/secrets-rotation.md
+++ b/docs/security/secrets-rotation.md
@@ -2,11 +2,45 @@
 
 **Policy:** Ledger §19.5, §25.x. No secret values in this document or in logs.
 
-This document covers rotation ownership, how to rotate each token, how Doppler is updated, and how the Token Healthcheck detects failures.
+This document covers rotation ownership, auto vs manual rotation, Doppler config for CI, required scopes, how to rotate each token, how Doppler is updated, runbooks for failure, and how the Token Healthcheck detects failures.
 
 ---
 
-## 1. Rotation ownership
+## 1. Auto-rotated vs manual secrets
+
+| Secret | Automation | Cadence | Notes |
+|--------|------------|---------|--------|
+| SENDGRID_API_KEY | Auto (workflow + script) | Weekly (Sunday 07:00 UTC) | Create new key via API → write to Doppler → verify → (revoke old manually if desired) |
+| TWILIO_ACCOUNT_SID / TWILIO_AUTH_TOKEN | Manual | Per org policy | No API to create/revoke auth token; regenerate in Twilio console, update Doppler |
+| YOCO_* | Manual | Per Yoco guidance | No API rotation; rotate in Yoco dashboard, update Doppler |
+| DOPPLER_TOKEN_CI | Manual | 90 days (§25.1) | GitHub Actions secret only; create new in Doppler, update repo secret |
+| GITHUB_TOKEN | N/A (built-in) | Per run | Use `github.token` in CI; no rotation |
+| GH_TOKEN (PAT) | Manual | If kept, per org policy | Prefer removal; store in Doppler for local use only |
+| SUPABASE_* | Manual | Per Supabase / org | Rotate in Supabase, update Doppler |
+
+---
+
+## 2. Doppler config for CI
+
+- **Healthcheck and rotation** use Doppler config **`ci`** so CI secrets are consistent and intentional.
+- Create a **`ci`** config in the Doppler project `tippy` (e.g. duplicate from `dev`). Store CI-only secrets there (e.g. SENDGRID_API_KEY, TWILIO_*, YOCO_* for tests, DOPPLER_TOKEN_ROTATOR if using rotation).
+- If **`ci`** does not exist yet, either create it in Doppler or temporarily change the workflow(s) to use config **`dev`** until `ci` is created.
+- **DOPPLER_TOKEN_CI** (in GitHub Actions secrets) must have read access to the `ci` config (or `dev` if using that).
+
+---
+
+## 3. Required scopes
+
+| Token / key | Scope | Where stored |
+|-------------|--------|--------------|
+| DOPPLER_TOKEN_CI | Doppler: read-only, project `tippy`, config `ci` (or dev) | GitHub Actions repo secret |
+| DOPPLER_TOKEN_ROTATOR | Doppler: write secrets, project `tippy`, config `ci` (least privilege) | Doppler `ci` config only (not in repo) |
+| SENDGRID_API_KEY | SendGrid: API Keys create + send (or full) | Doppler `ci` / `dev` |
+| GITHUB_TOKEN | N/A (Actions built-in) | Injected per job |
+
+---
+
+## 4. Rotation ownership
 
 | Secret / token | Owner | Rotation cadence |
 |----------------|--------|-------------------|
@@ -19,7 +53,7 @@ This document covers rotation ownership, how to rotate each token, how Doppler i
 
 ---
 
-## 2. How to rotate each token
+## 5. How to rotate each token
 
 ### 2.1 DOPPLER_TOKEN_CI
 
@@ -61,31 +95,50 @@ This document covers rotation ownership, how to rotate each token, how Doppler i
 
 ---
 
-## 3. How Doppler gets updated
+## 6. How Doppler gets updated
 
-- **CI:** Only `DOPPLER_TOKEN_CI` is stored in GitHub Actions secrets. All other app secrets are fetched at runtime via `doppler run --project tippy --config <config> -- <command>`.
-- **Doppler updates:** Edit secrets in the Doppler dashboard for project `tippy` and the appropriate config (`dev`, `staging`, `production`), or use Doppler CLI with an appropriate token (e.g. admin or “secrets updater” token) to run `doppler secrets set ...`. Never commit secret values to the repo.
-- **Optional automation:** For providers that support key rotation via API, a follow-up could implement a small job (e.g. scheduled or manual) that creates a new key, updates Doppler via the Doppler API using a limited “secrets updater” service token, then deactivates the old key. This is not yet implemented; document here when added.
+- **CI:** Only `DOPPLER_TOKEN_CI` is stored in GitHub Actions secrets. All other app secrets are fetched at runtime via `doppler run --project tippy --config ci -- <command>` (or `dev` if `ci` not used).
+- **Doppler updates:** Edit secrets in the Doppler dashboard for project `tippy` and the appropriate config (`ci`, `dev`, `staging`, `production`), or use Doppler CLI with an appropriate token. The **Secrets Rotation** workflow uses `DOPPLER_TOKEN_ROTATOR` (stored in Doppler `ci` config) to write updated secrets via the Doppler API. Never commit secret values to the repo.
 
 ---
 
-## 4. How the healthcheck detects failures
+## 7. How the healthcheck detects failures
 
-- **Workflow:** `.github/workflows/token-healthcheck.yml` runs on a weekly schedule (Sunday 07:00 UTC) and on `workflow_dispatch`.
+- **Workflow:** `.github/workflows/token-healthcheck.yml` runs weekly (Sunday 07:00 UTC) and on `workflow_dispatch`. It uses Doppler config **`ci`** and passes **GITHUB_TOKEN** from `github.token` so the GitHub check does not require a PAT.
 - **Doppler:** The workflow passes `DOPPLER_TOKEN_CI` into the job; the “Validate Doppler token” step runs `doppler run ... echo "Doppler OK"`. If the token is invalid, that step fails.
-- **App tokens:** The “Run token validation” step runs `doppler run ... npx tsx scripts/validate_tokens.ts`. The script calls:
-  - GitHub: `GET /rate_limit` → VALID (200) or INVALID (401/403).
-  - SendGrid: `GET /v3/user/account` → VALID (200) or INVALID (non-200).
-  - Twilio: `GET /Accounts/<sid>.json` with Basic auth → VALID (200) or INVALID (non-200).
-  - Yoco: no API call; status UNKNOWN (script does not fail the run for Yoco).
-- **Output:** The script prints only token *names* and status (VALID / INVALID / SKIP / UNKNOWN) and, for failures, HTTP status code. It never prints secret values.
-- **On failure:** If any validated token is INVALID, the workflow fails and the “Create or update Token Healthcheck Failed issue” step runs. It creates a new open issue titled **Token Healthcheck Failed** or adds a comment to an existing open issue with the same title, listing the failed token names and where they are used (file/workflow references). No secrets are included in the issue.
+- **App tokens:** The “Run token validation” step runs `doppler run ... npx tsx scripts/validate_tokens.ts`. The script checks:
+  - **GITHUB_TOKEN** (from Actions) and optionally **GH_TOKEN** (from Doppler): `GET /rate_limit` → VALID (200) or INVALID (401/403). GH_TOKEN is optional; if missing, reported as SKIP.
+  - SendGrid: `GET /v3/user/account` → VALID (200) or INVALID (non-200). SKIP if not set.
+  - Twilio: `GET /Accounts/<sid>.json` with Basic auth → VALID (200) or INVALID (non-200). SKIP if not set.
+  - Yoco: no API call; status UNKNOWN.
+- **Output:** The script prints only token *names* and status (e.g. `GITHUB_TOKEN: VALID (200)`, `SENDGRID_API_KEY: SKIP`). It never prints secret values.
+- **On failure:** If any validated token is INVALID, the workflow fails and the “Create or update Token Healthcheck Failed issue” step runs. No secrets are included in the issue.
 
 ---
 
-## 5. References
+## 8. Runbooks for failure
+
+### Token Healthcheck Failed
+
+1. Open the workflow run and read the “Run token validation” step output (token names and status only).
+2. For each INVALID token: rotate or fix the credential at the provider (or in Doppler), then re-run the workflow.
+3. If **GITHUB_TOKEN** is INVALID, the job is misconfigured (e.g. permissions); fix the workflow or repo settings.
+4. If **Doppler** step fails, rotate or fix **DOPPLER_TOKEN_CI** in GitHub Actions secrets per §25.1.
+
+### Secrets Rotation Failed
+
+1. Open the workflow run and read the “Run secrets rotation” step output (secret names and status only, no values).
+2. If **SENDGRID_API_KEY** failed: check SendGrid dashboard (rate limits, key permissions); ensure **DOPPLER_TOKEN_ROTATOR** in Doppler `ci` config has write access to the `tippy` project.
+3. If Doppler API errors: verify **DOPPLER_TOKEN_ROTATOR** is a write-capable token for project `tippy`, config `ci`.
+4. Manual secrets (Twilio, Yoco): rotate in provider dashboard and update Doppler; no automation.
+
+---
+
+## 9. References
 
 - `docs/security/token-audit-report.md` — inventory, sources, validation methods, status
 - `scripts/validate_tokens.ts` — validation script
+- `scripts/rotate_secrets.ts` — rotation orchestrator (no secret output)
 - `.github/workflows/token-healthcheck.yml` — healthcheck workflow
+- `.github/workflows/secrets-rotation.yml` — secrets rotation workflow
 - Ledger §19.5, §25.1, §25.2

--- a/scripts/rotate_secrets.ts
+++ b/scripts/rotate_secrets.ts
@@ -1,0 +1,119 @@
+/**
+ * Secrets rotation orchestrator: rotate provider secrets, write to Doppler, verify.
+ * Never prints secret values. Use with: doppler run --project tippy --config ci -- npx tsx scripts/rotate_secrets.ts
+ * Requires DOPPLER_TOKEN_ROTATOR in Doppler (ci config) for writing secrets back.
+ */
+
+const DOPPLER_API = 'https://api.doppler.com/v3/configs/config/secrets';
+const PROJECT = process.env.DOPPLER_PROJECT || 'tippy';
+const CONFIG = process.env.DOPPLER_CONFIG || 'ci';
+
+function log(line: string): void {
+  if (process.stdout.writable) process.stdout.write(line + '\n');
+}
+
+async function dopplerUpdateSecrets(secrets: Record<string, string>, token: string): Promise<boolean> {
+  const url = `${DOPPLER_API}?project=${encodeURIComponent(PROJECT)}&config=${encodeURIComponent(CONFIG)}`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ secrets }),
+  });
+  return res.ok;
+}
+
+async function rotateSendGrid(): Promise<void> {
+  const apiKey = process.env.SENDGRID_API_KEY;
+  const rotatorToken = process.env.DOPPLER_TOKEN_ROTATOR;
+
+  if (!rotatorToken?.trim()) {
+    log('SENDGRID_API_KEY: SKIP (no DOPPLER_TOKEN_ROTATOR)');
+    return;
+  }
+  if (!apiKey?.trim()) {
+    log('SENDGRID_API_KEY: SKIP (not set)');
+    return;
+  }
+
+  try {
+    const name = `tippy-rotated-${Date.now()}`;
+    const createRes = await fetch('https://api.sendgrid.com/v3/api_keys', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ name }),
+    });
+
+    if (!createRes.ok) {
+      const err = await createRes.text();
+      log(`SENDGRID_API_KEY: FAILED (create ${createRes.status})`);
+      throw new Error(`SendGrid create key failed: ${createRes.status}`);
+    }
+
+    const data = (await createRes.json()) as { api_key?: string; api_key_id?: string };
+    const newKey = data.api_key;
+    if (!newKey) {
+      log('SENDGRID_API_KEY: FAILED (no key in response)');
+      throw new Error('SendGrid response missing api_key');
+    }
+
+    const updated = await dopplerUpdateSecrets({ SENDGRID_API_KEY: newKey }, rotatorToken);
+    if (!updated) {
+      log('SENDGRID_API_KEY: FAILED (Doppler update failed)');
+      throw new Error('Doppler update failed');
+    }
+
+    const verifyRes = await fetch('https://api.sendgrid.com/v3/user/account', {
+      headers: { Authorization: `Bearer ${newKey}` },
+    });
+    if (!verifyRes.ok) {
+      log('SENDGRID_API_KEY: FAILED (verify failed after write)');
+      throw new Error('Verification failed');
+    }
+
+    log('SENDGRID_API_KEY: ROTATED');
+  } catch (e) {
+    log(`SENDGRID_API_KEY: FAILED (${e instanceof Error ? e.message : String(e)})`);
+    throw e;
+  }
+}
+
+function rotateTwilio(): void {
+  log('TWILIO_ACCOUNT_SID/TWILIO_AUTH_TOKEN: MANUAL (no API rotation)');
+}
+
+function rotateYoco(): void {
+  log('YOCO_*: MANUAL (no API rotation)');
+}
+
+async function main(): Promise<void> {
+  log('Secrets rotation (names and status only, no values)');
+  let failed = false;
+
+  if (process.env.SENDGRID_API_KEY?.trim() && process.env.DOPPLER_TOKEN_ROTATOR?.trim()) {
+    try {
+      await rotateSendGrid();
+    } catch {
+      failed = true;
+    }
+  } else {
+    if (process.env.SENDGRID_API_KEY?.trim()) log('SENDGRID_API_KEY: SKIP (no DOPPLER_TOKEN_ROTATOR)');
+    else log('SENDGRID_API_KEY: SKIP (not set)');
+  }
+
+  rotateTwilio();
+  rotateYoco();
+
+  if (failed) process.exit(1);
+  process.exit(0);
+}
+
+main().catch((e) => {
+  log(`FATAL: ${e instanceof Error ? e.message : String(e)}`);
+  process.exit(1);
+});


### PR DESCRIPTION
Summary:
- Token healthcheck uses GITHUB_TOKEN from Actions (no PAT required); GH_TOKEN optional (SKIP if missing). Uses Doppler config ci.
- Validator prints ENV_NAME: STATUS (HTTP_CODE); SendGrid/Twilio SKIP when absent; Yoco UNKNOWN.
- New Secrets Rotation workflow (weekly + dispatch) runs rotate_secrets.ts via Doppler ci config.
- rotate_secrets.ts: SendGrid create key -> write to Doppler via API -> verify; Twilio and Yoco marked MANUAL (no API). Requires DOPPLER_TOKEN_ROTATOR in Doppler for writeback.
- Docs: auto vs manual table, Doppler ci config, required scopes, runbooks for healthcheck and rotation failure.

No secrets in code, logs, or PR. DOPPLER_TOKEN_CI remains in GitHub Actions only.

Made with [Cursor](https://cursor.com)